### PR TITLE
[FIX] Limit Top Posts Count in Discourse Module 

### DIFF
--- a/cms/config/functions/cron.js
+++ b/cms/config/functions/cron.js
@@ -20,7 +20,7 @@ module.exports = {
   //
   // }
   '*/5 * * * *': () => {
-    getLatestCommunityActivity(20);
+    getLatestCommunityActivity(15);
   },
   '*/60 * * * * *': () => {
     getCommunityContributors('https://gsoc.rocket.chat/api/data','rocketChat','Rocket.Chat');

--- a/cms/config/functions/cron.js
+++ b/cms/config/functions/cron.js
@@ -20,7 +20,7 @@ module.exports = {
   //
   // }
   '*/5 * * * *': () => {
-    getLatestCommunityActivity();
+    getLatestCommunityActivity(20);
   },
   '*/60 * * * * *': () => {
     getCommunityContributors('https://gsoc.rocket.chat/api/data','rocketChat','Rocket.Chat');

--- a/cms/config/functions/fetchTopPosts.js
+++ b/cms/config/functions/fetchTopPosts.js
@@ -1,8 +1,8 @@
 const axios = require("axios");
 
-module.exports.getLatestCommunityActivity = async () => {
+module.exports.getLatestCommunityActivity = async (maximumPostCount) => {
   // only run if env var is set, and don't break server
-  if ('DISCOURSE_DOMAIN' in Object.keys(process.env)) {
+  if ("DISCOURSE_DOMAIN" in Object.keys(process.env)) {
     const TopPost = await axios({
       url: `${process.env.DISCOURSE_DOMAIN}/top.json?period=all`,
       method: "GET",
@@ -11,14 +11,23 @@ module.exports.getLatestCommunityActivity = async () => {
         "Api-Key": process.env.DISCOURSE_API_KEY,
       },
     });
-    let currentTopPost = await strapi.query("discourse").find();
-    if (currentTopPost.length !== 0) {
-      await strapi.query("discourse").update(
-        { id: currentTopPost[0].id },
-        {
-          TopPost: TopPost.data,
+    let currentTopPosts = await strapi.query("discourse").find();
+    if (currentTopPosts.length !== 0) {
+      let excessPostsCount = currentTopPost.length - maximumPostCount + 1;
+      if (
+        JSON.stringify(currentTopPosts[currentTopPosts.length - 1].TopPost) !==
+        JSON.stringify(TopPost.data)
+      ) {
+        for (let post of currentTopPosts) {
+          if (excessPostsCount > 0) {
+            await strapi.query("discourse").delete({ id: post.id });
+            excessPostsCount -= 1;
+          }
         }
-      );
+        await strapi.query("discourse").create({
+          TopPost: TopPost.data,
+        });
+      }
     } else {
       await strapi.query("discourse").create({
         TopPost: TopPost.data,


### PR DESCRIPTION


  -  [x] I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  -  [x] I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - [x] Lint and unit tests pass locally with my changes
  - [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
  -  [ ] I have added necessary documentation (if applicable)
  - [x] Any dependent changes have been merged and published in downstream modules

## Proposed changes (including videos or screenshots)

- Made changes in the discourse module so that only the top N entries are stored in the CMS. 
- Included checks to make sure that the same TopPost does not populate the database.
- On Every Call the excess old posts will be deleted and  new fresh TopPost will be added.

## Issue(s)

Fixes : #21  
