### PR TITLE
[IMPROVE] Inappchat improvements and fixes

### DIFF
--- a/app/components/inappchat/helpers/index.js
+++ b/app/components/inappchat/helpers/index.js
@@ -1,4 +1,3 @@
 export { default as messagesSortedByDate } from './sortMessagesByDate';
 export { default as emojify } from './emojify';
 export { emojis } from './emojisThatAnimate';
-export { useSsl, rcURL } from './url';

--- a/app/components/inappchat/helpers/url.js
+++ b/app/components/inappchat/helpers/url.js
@@ -1,7 +1,0 @@
-// uses localhost:3000 for development and the domain provided in .env in prod
-let url = process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : process.env.NEXT_PUBLIC_ROCKET_CHAT_HOST;
-
-export const rcURL = new URL(url);
-
-// Use useSsl: false only if server url starts with http://
-export const useSsl = !/http:\/\//.test(url);

--- a/app/components/inappchat/helpers/url.js
+++ b/app/components/inappchat/helpers/url.js
@@ -4,4 +4,4 @@ let url = process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : pro
 export const rcURL = new URL(url);
 
 // Use useSsl: false only if server url starts with http://
-export const useSsl = () => !/http:\/\//.test(url);
+export const useSsl = !/http:\/\//.test(url);

--- a/app/components/inappchat/inappchat.js
+++ b/app/components/inappchat/inappchat.js
@@ -41,8 +41,12 @@ const InAppChat = ({ closeChat, cookies, rid }) => {
       }
     };
     async function getData() {
-      const data = await getMessages(rid, cookies);
-      setMessages(data.messages);
+      try {
+        const data = await getMessages(rid, cookies);
+        setMessages(data.messages);
+      } catch (err) {
+        console.log(err.message);
+      }
     }
     getData();
     runRealtime(cookies.rc_token, rid);

--- a/app/components/inappchat/inappchat.js
+++ b/app/components/inappchat/inappchat.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { Rocketchat } from "@rocket.chat/sdk";
+import Cookie from 'js-cookie';
 import { getMessages, sendMessage } from "./lib/api";
 import styles from "../../styles/Inappchat.module.css";
 import { emojify, messagesSortedByDate } from "./helpers";
@@ -22,8 +23,9 @@ import InappchatTextInput from "./inappchattextinput";
 
 const rcClient = new Rocketchat({ logger: console, protocol: "ddp" });
 
-const InAppChat = ({ host, closeChat, cookies, rid }) => {
+const InAppChat = ({ host, closeChat, rid }) => {
   const [messages, setMessages] = useState([]);
+  const cookies = { rc_token: Cookie.get('rc_token'), rc_uid: Cookie.get('rc_uid') };
   const isAuth = cookies.rc_token && cookies.rc_uid;
   const rcURL = new URL(host);
   const useSsl = !/http:\/\//.test(host);
@@ -97,7 +99,7 @@ const InAppChat = ({ host, closeChat, cookies, rid }) => {
           ) : (
             <p>
               Please login into{" "}
-              <a href={host} target="_blank">
+              <a href={host} rel="noopener noreferrer" target="_blank">
                 RocketChat
               </a>{" "}
               to chat!
@@ -105,7 +107,7 @@ const InAppChat = ({ host, closeChat, cookies, rid }) => {
           )}
         </Box>
       </div>
-      {cookies.rc_token && cookies.rc_uid && <InappchatTextInput sendMsg={sendMsg} />}
+      {isAuth && <InappchatTextInput sendMsg={sendMsg} />}
     </div>
   );
 };

--- a/app/components/inappchat/lib/api.js
+++ b/app/components/inappchat/lib/api.js
@@ -1,9 +1,7 @@
-import { rcURL } from "../helpers";
-
-export const getMessages = async (rid, cookies) => {
+export const getMessages = async (host, rid, cookies) => {
   try {
     const messages = await fetch(
-      `${rcURL.origin}/api/v1/channels.messages?roomId=${rid}`,
+      `${host}/api/v1/channels.messages?roomId=${rid}`,
       {
         headers: {
           "Content-Type": "application/json",
@@ -20,9 +18,9 @@ export const getMessages = async (rid, cookies) => {
   }
 };
 
-export const sendMessage = async (rid, message, cookies) => {
+export const sendMessage = async (host, rid, message, cookies) => {
   try {
-    const msg = await fetch(`${rcURL.origin}/api/v1/chat.sendMessage`, {
+    const msg = await fetch(`${host}/api/v1/chat.sendMessage`, {
       body: `{"message": { "rid": "${rid}", "msg": "${message}" }}`,
       headers: {
         "Content-Type": "application/json",

--- a/app/package.json
+++ b/app/package.json
@@ -19,6 +19,7 @@
     "dompurify": "^2.3.5",
     "emoji-toolkit": "^6.6.0",
     "firebase": "^9.6.3",
+    "js-cookie": "^3.0.1",
     "marked": "^4.0.12",
     "next": "12.0.7",
     "next-auth": "^4.2.1",

--- a/app/pages/virtualconf/greenroom/index.js
+++ b/app/pages/virtualconf/greenroom/index.js
@@ -23,7 +23,7 @@ const Greenroom = ({ cookies }) => {
 				<div className={styles.container}>
 				</div>
 				{openChat ? (
-          			<InAppChat closeChat={handleOpenChat} cookies={cookies} rid={greenroom_rid} />
+          			<InAppChat host="http://localhost:3000" closeChat={handleOpenChat} cookies={cookies} rid={greenroom_rid} />
         			) : (
           			<Button style={{ float: 'right' }} onClick={handleOpenChat}>Open Chat</Button>
         		)}

--- a/app/pages/virtualconf/greenroom/index.js
+++ b/app/pages/virtualconf/greenroom/index.js
@@ -7,8 +7,9 @@ import InAppChat from "../../../components/inappchat/inappchat";
 import { Button } from "react-bootstrap";
 
 const greenroom_rid = process.env.NEXT_PUBLIC_ROCKET_CHAT_GREENROOM_RID;
+const host = process.env.NODE_ENV === "development" ? "http://localhost:3000" : "https://community.liaison.rocketchat.digital";
 
-const Greenroom = ({ cookies }) => {
+const Greenroom = () => {
 	const [openChat, setOpenChat] = useState(false);
 
   	const handleOpenChat = () => {
@@ -23,7 +24,7 @@ const Greenroom = ({ cookies }) => {
 				<div className={styles.container}>
 				</div>
 				{openChat ? (
-          			<InAppChat host="http://localhost:3000" closeChat={handleOpenChat} cookies={cookies} rid={greenroom_rid} />
+          			<InAppChat host={host} closeChat={handleOpenChat} rid={greenroom_rid} />
         			) : (
           			<Button style={{ float: 'right' }} onClick={handleOpenChat}>Open Chat</Button>
         		)}
@@ -41,11 +42,3 @@ const Greenroom = ({ cookies }) => {
 }
 
 export default Greenroom;
-
-Greenroom.getInitialProps = ({ req }) => {
-	const cookies = req.cookies;
-  
-	return {
-	  cookies,
-	};
-  };

--- a/app/pages/virtualconf/mainstage/[id].js
+++ b/app/pages/virtualconf/mainstage/[id].js
@@ -32,7 +32,7 @@ export default function ConfMainStage({ cookies }) {
             
         </Container>
         {openChat ? (
-          <InAppChat closeChat={handleOpenChat} cookies={cookies} rid={rid} />
+          <InAppChat host="http://localhost:3000" closeChat={handleOpenChat} cookies={cookies} rid={rid} />
         ) : (
           <Button onClick={handleOpenChat}>Open Chat</Button>
         )}

--- a/app/pages/virtualconf/mainstage/[id].js
+++ b/app/pages/virtualconf/mainstage/[id].js
@@ -5,8 +5,9 @@ import Videostreamer from "../../../components/clientsideonly/videostreamer";
 import InAppChat from '../../../components/inappchat/inappchat';
 
 const rid = process.env.NEXT_PUBLIC_ROCKET_CHAT_CONF_RID;
+const host = process.env.NODE_ENV === "development" ? "http://localhost:3000" : "https://community.liaison.rocketchat.digital";
 
-export default function ConfMainStage({ cookies }) {
+export default function ConfMainStage() {
   const [openChat, setOpenChat] = useState(false);
 
   const handleOpenChat = () => {
@@ -32,7 +33,7 @@ export default function ConfMainStage({ cookies }) {
             
         </Container>
         {openChat ? (
-          <InAppChat host="http://localhost:3000" closeChat={handleOpenChat} cookies={cookies} rid={rid} />
+          <InAppChat host={host} closeChat={handleOpenChat} rid={rid} />
         ) : (
           <Button onClick={handleOpenChat}>Open Chat</Button>
         )}
@@ -40,11 +41,3 @@ export default function ConfMainStage({ cookies }) {
     </>
   );
 }
-
-ConfMainStage.getInitialProps = ({ req }) => {
-  const cookies = req.cookies;
-
-  return {
-    cookies,
-  };
-};


### PR DESCRIPTION
- `useSsl` was treated as a function that didn't give us a resolved value
- error handling an edge case (if we don't provide a valid rid or any rid)
- added `host` as a component level parameter and removed the env variable dependency, at development, it points to `http://localhost:3000`, and in prod (as of now) it resolves into Debdut sir's RC instance (which is https://community.liaison.rocketchat.digital/)
- now cookies are handled at the component level