### PR TITLE
[FIX] Hide Jitsi Logs  using `showLogs` props

### DIFF
--- a/app/components/clientsideonly/jitsibroadcaster.js
+++ b/app/components/clientsideonly/jitsibroadcaster.js
@@ -39,6 +39,9 @@ const Jitsibroadcaster = ({ room, disName, rtmpSrc, handleChat }) => {
     { speaker: "Z", hour: "50" },
   ];
 
+  //Set "showLogs" to true if you want to see logs for debugging
+  const showLogs = true;
+
   const handleDisplayName = async (hr) => {
     const tar = dataArr.find((o) => o.hour === hr);
     if (!tar || tar.speaker == name) {
@@ -398,7 +401,7 @@ const Jitsibroadcaster = ({ room, disName, rtmpSrc, handleChat }) => {
     </div>
   );
 
-  const renderLog = () =>
+  const renderLog = () =>{
     logItems.map((item, index) => (
       <div
         style={{
@@ -410,7 +413,8 @@ const Jitsibroadcaster = ({ room, disName, rtmpSrc, handleChat }) => {
         {item}
       </div>
     ));
-
+  }
+  
   const renderSpinner = () => (
     <div
       style={{
@@ -465,6 +469,7 @@ const Jitsibroadcaster = ({ room, disName, rtmpSrc, handleChat }) => {
         {toggleView()}
       </div>
       {toolButton()}
+      {showLogs && <div className={styles.log}>{renderLog()}</div>}
     </>
   );
 };

--- a/app/components/clientsideonly/jitsibroadcaster.js
+++ b/app/components/clientsideonly/jitsibroadcaster.js
@@ -25,13 +25,12 @@ const JitsiMeeting = dynamic(
 
 const rtmp = process.env.NEXT_PUBLIC_ROCKET_CHAT_GREENROOM_RTMP;
 
-const Jitsibroadcaster = ({ room, disName, rtmpSrc, handleChat }) => {
+const Jitsibroadcaster = ({ room, disName, rtmpSrc, handleChat, showLogs }) => {
   const apiRef = useRef();
   const [logItems, updateLog] = useState([]);
   const [knockingParticipants, updateKnockingParticipants] = useState([]);
   const [mute, setMute] = useState(true);
   const [name, setName] = useState(null);
-  const [showLogs ,setShowLogs]  = useState(false);
   const dataArr = [
     { speaker: "A", hour: "10" },
     { speaker: "B", hour: "20" },
@@ -395,14 +394,6 @@ const Jitsibroadcaster = ({ room, disName, rtmpSrc, handleChat }) => {
         <Button color="#f5455c" onClick={handleChat}>
           <FaRocketchat />
         </Button>
-        <DropdownButton variant="light" as={ButtonGroup} title="">
-          <Dropdown.Item
-            as="button"
-            onClick={() => setShowLogs(!showLogs) }
-          >
-            {showLogs ? (<span>Hide Logs</span>) : (<span>Show Logs</span>) }
-          </Dropdown.Item>
-        </DropdownButton>
       </ButtonGroup>
     </div>
   );

--- a/app/components/clientsideonly/jitsibroadcaster.js
+++ b/app/components/clientsideonly/jitsibroadcaster.js
@@ -31,6 +31,7 @@ const Jitsibroadcaster = ({ room, disName, rtmpSrc, handleChat }) => {
   const [knockingParticipants, updateKnockingParticipants] = useState([]);
   const [mute, setMute] = useState(true);
   const [name, setName] = useState(null);
+  const [showLogs ,setShowLogs]  = useState(false);
   const dataArr = [
     { speaker: "A", hour: "10" },
     { speaker: "B", hour: "20" },
@@ -38,9 +39,6 @@ const Jitsibroadcaster = ({ room, disName, rtmpSrc, handleChat }) => {
     { speaker: "D", hour: "40" },
     { speaker: "Z", hour: "50" },
   ];
-
-  //Set "showLogs" to true if you want to see logs for debugging
-  const showLogs = false;
 
   const handleDisplayName = async (hr) => {
     const tar = dataArr.find((o) => o.hour === hr);
@@ -397,6 +395,14 @@ const Jitsibroadcaster = ({ room, disName, rtmpSrc, handleChat }) => {
         <Button color="#f5455c" onClick={handleChat}>
           <FaRocketchat />
         </Button>
+        <DropdownButton variant="light" as={ButtonGroup} title="">
+          <Dropdown.Item
+            as="button"
+            onClick={() => setShowLogs(!showLogs) }
+          >
+            {showLogs ? (<span>Hide Logs</span>) : (<span>Show Logs</span>) }
+          </Dropdown.Item>
+        </DropdownButton>
       </ButtonGroup>
     </div>
   );

--- a/app/components/clientsideonly/jitsibroadcaster.js
+++ b/app/components/clientsideonly/jitsibroadcaster.js
@@ -465,7 +465,6 @@ const Jitsibroadcaster = ({ room, disName, rtmpSrc, handleChat }) => {
         {toggleView()}
       </div>
       {toolButton()}
-      <div className={styles.log}>{renderLog()}</div>
     </>
   );
 };

--- a/app/components/clientsideonly/jitsibroadcaster.js
+++ b/app/components/clientsideonly/jitsibroadcaster.js
@@ -401,7 +401,7 @@ const Jitsibroadcaster = ({ room, disName, rtmpSrc, handleChat }) => {
     </div>
   );
 
-  const renderLog = () =>{
+  const renderLog = () =>
     logItems.map((item, index) => (
       <div
         style={{
@@ -413,7 +413,7 @@ const Jitsibroadcaster = ({ room, disName, rtmpSrc, handleChat }) => {
         {item}
       </div>
     ));
-  }
+  
   
   const renderSpinner = () => (
     <div

--- a/app/components/clientsideonly/jitsibroadcaster.js
+++ b/app/components/clientsideonly/jitsibroadcaster.js
@@ -40,7 +40,7 @@ const Jitsibroadcaster = ({ room, disName, rtmpSrc, handleChat }) => {
   ];
 
   //Set "showLogs" to true if you want to see logs for debugging
-  const showLogs = true;
+  const showLogs = false;
 
   const handleDisplayName = async (hr) => {
     const tar = dataArr.find((o) => o.hour === hr);

--- a/app/pages/virtualconf/greenroom/index.js
+++ b/app/pages/virtualconf/greenroom/index.js
@@ -29,6 +29,7 @@ const Greenroom = () => {
                 room={"GSOC Alumnus Meet"}
                 disName={"Speaker"}
                 handleChat={handleOpenChat}
+                showLogs={false}
               />
             </Col>
             {openChat && (

--- a/app/pages/virtualconf/greenroom/index.js
+++ b/app/pages/virtualconf/greenroom/index.js
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import Head from "next/head";
-import styles from "../../../styles/Mainstage.module.css";
+import styles from "../../../styles/Greenroom.module.css";
 import { Container, Row, Col } from "react-bootstrap";
 import Jitsibroadcaster from "../../../components/clientsideonly/jitsibroadcaster";
 import InAppChat from "../../../components/inappchat/inappchat";

--- a/app/styles/Greenroom.module.css
+++ b/app/styles/Greenroom.module.css
@@ -2,7 +2,8 @@
 
 .main {
   font-family: "Roboto", sans-serif;
-  height: 90vh;
+  min-height: 90vh;
+  max-height: fit-content;
 }
 
 .topNav {

--- a/app/styles/Greenroom.module.css
+++ b/app/styles/Greenroom.module.css
@@ -2,6 +2,7 @@
 
 .main {
   font-family: "Roboto", sans-serif;
+  height: 90vh;
 }
 
 .topNav {


### PR DESCRIPTION
-  [x] I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  -  [x] I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - [x] Lint and unit tests pass locally with my changes
  - [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
  -  [x] I have added necessary documentation (if applicable)
  - [x] Any dependent changes have been merged and published in downstream modules

## Issues

Mentioned in the issue #131 

## Proposed changes (including videos or screenshots)

- Add `showLogs` props top `<Jitsibroadcaster ... />` component which can be set to true to view logs and false to hide logs



https://user-images.githubusercontent.com/70485812/161915539-ed76c9ca-05c8-422f-a95c-6068b28e4e2a.mp4







