### PR TITLE
[FEAT] Issue form templates for easier and better issue creation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,93 @@
+name: Report a Bug
+title: '[BUG][Module Name] Bug title'
+description: Problems and issues with code of RC4Community
+labels: ['type/bug']
+body:
+  - type: markdown
+    attributes:
+      value: >
+        - Please make sure what you are reporting is indeed a bug with reproducible steps
+
+        - If you want to ask questions or share ideas, you can,
+          -  Head to our [Forums](https://forums.rocket.chat) Page
+          - [Join our Open Server]( https://open.rocket.chat/channel/support) and send your question
+
+        For better global communication, please write in English.
+
+  - type: checkboxes
+    attributes:
+      label: Search before asking
+      description: >
+        Please make sure to search in the existing [issues](https://github.com/RocketChat/RC4Community/issues?q=is%3Aissue)
+        first to see whether the same issue was reported already.
+      options:
+        - label: >
+            I had searched in the [issues](https://github.com/RocketChat/RC4Community/issues?q=is%3Aissue) and found
+            no similar issues.
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Describe the bug
+      description: |
+        Please provide the context in which the problem occurred and explain what happened
+
+        Is there any setting relevant to the problem that changed?
+      placeholder: A clear and concise description of what the bug is
+
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: How to Reproduce
+      description: |
+        Explain the steps to reproduce the behavior:
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+      placeholder: >
+        Please make sure you provide a reproducible step-by-step case of how to reproduce the problem
+        as minimally and precisely as possible
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Describe your Expected behavior
+      description: |
+        - Please explain why you think the behaviour is erroneous.
+
+        - It will be extremely helpful if you copy and paste
+          screenshots for UI problems
+      placeholder: A clear and concise description of what you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Anything else
+      description: |
+        1. How often does this problem occur?
+            - Once?
+            - Every time?
+            - Only when certain conditions are met?
+        2. Any relevant logs to include?
+            - Put them here inside fenced \``` \``` blocks
+            - Or put them inside a collapsable details tag if it's too long, like so:
+              - `<details><summary>x.log</summary> lots of stuff </details>`
+      placeholder: Anything else we need to know?
+
+  - type: checkboxes
+    attributes:
+      label: Are you willing to submit PR?
+      description: |
+        - We would be happy to guide you in the contribution process especially if you already have a good understanding of how to implement the fix.
+        - RC4Community is a **for the community - by the community** project and we would love to bring new contributors in.
+      options:
+        - label: Yes, I am willing to submit a PR!
+
+  - type: markdown
+    attributes:
+      value: 'Thank you for submitting your issue, we really appreciate it!'

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,46 @@
+name: Feature Request
+description: Suggest an idea for this project
+title: '[FEATURE][Module Name] Feature title'
+labels: ['type/feature-request']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For better global communication, please write in English.
+
+  - type: checkboxes
+    attributes:
+      label: Search before asking
+      description: >
+        Please make sure to search in the [issues](https://github.com/RocketChat/RC4Community/issues?q=is%3Aissue) first
+        to see whether the same feature was requested already.
+      options:
+        - label: >
+            I have searched in the [issues](https://github.com/RocketChat/RC4Community/issues?q=is%3Aissue) and found no
+            similar feature requirement.
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Description
+      description: A short description of your feature
+
+  - type: textarea
+    attributes:
+      label: Use case
+      description: What do you want to happen?
+      placeholder: >
+        Explain what you are trying to achieve
+
+  - type: checkboxes
+    attributes:
+      label: Are you willing to submit a PR?
+      description: |
+        - We would be happy to guide you in the contribution process especially if you already have a good understanding of how to implement the fix.
+        - RC4Community is a **for the community - by the community** project and we would love to bring new contributors in.
+      options:
+        - label: Yes I am willing to submit a PR!
+
+  - type: markdown
+    attributes:
+      value: 'Thanks for completing our form!'

--- a/.github/ISSUE_TEMPLATE/todo.yml
+++ b/.github/ISSUE_TEMPLATE/todo.yml
@@ -1,0 +1,46 @@
+name: TODO
+description: Task to be done in this project
+title: '[TODO][Module Name] Feature title'
+labels: ['type/feature-request']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For better global communication, please write in English.
+
+  - type: checkboxes
+    attributes:
+      label: Search before asking
+      description: >
+        Please make sure to search in the [issues](https://github.com/RocketChat/RC4Community/issues?q=is%3Aissue) first
+        to see whether the same feature was requested already.
+      options:
+        - label: >
+            I have searched in the [issues](https://github.com/RocketChat/RC4Community/issues?q=is%3Aissue) and found no
+            similar feature requirement.
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Description
+      description: A short of the task to be done....
+
+  - type: textarea
+    attributes:
+      label: Use case
+      description: Objectives of the task to be completed
+      placeholder: >
+        Explain what are the objectives of this task....
+
+  - type: checkboxes
+    attributes:
+      label: Are you willing to submit a PR?
+      description: |
+        - We would be happy to guide you in the contribution process especially if you already have a good understanding of how to implement the fix.
+        - RC4Community is a **for the community - by the community** project and we would love to bring new contributors in.
+      options:
+        - label: Yes I am willing to submit a PR!
+
+  - type: markdown
+    attributes:
+      value: 'Thanks for completing our form!'


### PR DESCRIPTION
## Suggested Changes

This might be really useful and convenient for the community to create new issues easily due to the simple form format and detailed instructions!!

Added 3 Issue form templates
1. Bug Report Template
<img width="615" alt="image" src="https://user-images.githubusercontent.com/73993394/205435582-5640ffae-388b-4989-a191-b8d99b02a841.png">

---

2. Feature Request Template
<img width="615" alt="image" src="https://user-images.githubusercontent.com/73993394/205435620-3c215df3-71ab-493a-bfa6-fa7b11ff2824.png">

---

3. Todo Request Template
(Similar to feature request template with modified description)
<img width="615" alt="image" src="https://user-images.githubusercontent.com/73993394/205435654-f3e8411c-8324-4cc6-a4e1-0aaa329e4c95.png">
