### PR TITLE
[FIX] Fixed responsiveness of News Carousel

### DIFF
--- a/app/components/newscarousel.js
+++ b/app/components/newscarousel.js
@@ -45,7 +45,7 @@ const NextArrow = ({ currentSlide, slideCount, onClick, ...props }) => {
 const Item = (props) => {
   return (
     <div
-      className={`bg-white m-2 h-auto + ${styles.active_carousel}`}
+      className={`bg-white + ${styles.active_carousel}`}
     >
       <a
         href={props.item.attributes.url}
@@ -54,8 +54,9 @@ const Item = (props) => {
         className='text-decoration-none text-black :hover'
       >
         <Image
-          width={200}
-          height={140}
+         className='news-image'
+         width={209}
+         height={134.44}
           src={props.item.attributes.imageUrl}
           alt={props.item.attributes.name}
         />

--- a/app/components/newscarousel.js
+++ b/app/components/newscarousel.js
@@ -45,7 +45,7 @@ const NextArrow = ({ currentSlide, slideCount, onClick, ...props }) => {
 const Item = (props) => {
   return (
     <div
-      className={`bg-white + ${styles.active_carousel}`}
+      className={`bg-white m-2 h-auto + ${styles.active_carousel}`}
     >
       <a
         href={props.item.attributes.url}
@@ -54,8 +54,8 @@ const Item = (props) => {
         className='text-decoration-none text-black :hover'
       >
         <Image
-         width={200}
-         height={140}
+          width={200}
+          height={140}
           src={props.item.attributes.imageUrl}
           alt={props.item.attributes.name}
         />
@@ -77,10 +77,19 @@ function Newscarousel(props) {
         arrows={true}
         infinite={true}
         speed={500}
-        slidesToShow={4}
-        slidesToScroll={4}
+        slidesToShow={5}
+        slidesToScroll={5}
         pauseOnHover={true}
         responsive={[
+          {
+            breakpoint: 1200,
+            settings: {
+              slidesToShow: 4,
+              slidesToScroll: 4,
+              infinite: true,
+              dots: true,
+            },
+          },
           {
             breakpoint: 1024,
             settings: {
@@ -91,11 +100,20 @@ function Newscarousel(props) {
             },
           },
           {
-            breakpoint: 600,
+            breakpoint: 720,
             settings: {
               slidesToShow: 2,
               slidesToScroll: 2,
-              initialSlide: 2,
+              infinite: true,
+              dots: true,
+            },
+          },
+          {
+            breakpoint: 430,
+            settings: {
+              slidesToShow: 1,
+              slidesToScroll: 1,
+              initialSlide: 1,
             },
           },
         ]}

--- a/app/components/newscarousel.js
+++ b/app/components/newscarousel.js
@@ -54,9 +54,8 @@ const Item = (props) => {
         className='text-decoration-none text-black :hover'
       >
         <Image
-         className='news-image'
-         width={209}
-         height={134.44}
+         width={200}
+         height={140}
           src={props.item.attributes.imageUrl}
           alt={props.item.attributes.name}
         />

--- a/app/components/newscarousel.js
+++ b/app/components/newscarousel.js
@@ -58,6 +58,7 @@ const Item = (props) => {
           height={140}
           src={props.item.attributes.imageUrl}
           alt={props.item.attributes.name}
+          className = {`${styles.imgItems}`}
         />
         <div className={`p-2 p-md-3 h-auto + ${styles.content}`}>
           <h2 className={`${styles.heading}`}>{props.item.attributes.name}</h2>

--- a/app/styles/Newscarousel.module.css
+++ b/app/styles/Newscarousel.module.css
@@ -1,14 +1,12 @@
 .slider {
-  width: 95%;
+  width: 90%;
   max-width: 90rem;
   align-self: center;
 }
 
 .active_carousel {
   position: relative;
-  width: min-content;
-  height: 300px;
-  margin: 24px 12px;
+  align-self: center;
 }
 
 .active_carousel:hover {
@@ -44,4 +42,7 @@
 
 .carousel-item-title {
   font-size: 22.5px;
+}
+.imgItems{
+  width: 100%;
 }

--- a/app/styles/Newscarousel.module.css
+++ b/app/styles/Newscarousel.module.css
@@ -3,23 +3,32 @@
   max-width: 90rem;
   align-self: center;
 }
+
 .active_carousel {
   position: relative;
+  width: min-content;
+  height: 300px;
+  margin: 24px 12px;
 }
+
 .active_carousel:hover {
   transform: scale(1.04);
   transition: 0.5s all;
+  z-index: 2;
 }
+
 .carousel-item-link {
   text-decoration: none;
   color: #000000;
   outline: none;
 }
+
 .active_carousel:hover .content {
   background-color: #1d74f5;
   color: white;
   transition: 0.5s all;
 }
+
 .carousel-item-image {
   width: 100%;
   height: 100%;


### PR DESCRIPTION
So I have fixed the responsiveness of news carousel section. Also I have made styles consistent. 

First fix was making the styles consistent and you can check the results below:-

**Before**

![fix1](https://user-images.githubusercontent.com/96231592/205439838-f6a36219-f190-4cfb-be2f-ed5e82b57ea8.png)

**After**

![fix1a](https://user-images.githubusercontent.com/96231592/205439853-c67bfcce-bd26-431e-98c6-241a04fffafe.png)


Second fix was making the section responsive. Earlier the text flowed outside the image. You can check the results below:- 
![r4c](https://user-images.githubusercontent.com/96231592/205440077-b81f48b7-7195-48d2-b473-d8b2122b830b.gif)


<a href="https://gitpod.io/#https://github.com/RocketChat/RC4Community/pull/208"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

