### PR TITLE
Added check if docker daemon is running or not before starting the scripts for both gitpod and local scripts

### DIFF
--- a/gitpod-scripts/startCloudDevBackend.sh
+++ b/gitpod-scripts/startCloudDevBackend.sh
@@ -1,6 +1,12 @@
 #!/bin/sh
 
+if ! docker info > /dev/null 2>&1; then
+  echo "Docker is not running, please start the Docker daemon and try again! 💪"
+  exit 1
+fi
+
 echo "--Starting Superprofile Backend--"
+
 cd superprofile
 sh initFaunaOnce.sh $1
 cd ..

--- a/gitpod-scripts/startCloudDevEnv.sh
+++ b/gitpod-scripts/startCloudDevEnv.sh
@@ -20,6 +20,11 @@ check_and_set_next_port() {
     fi
 }
 
+if ! docker info > /dev/null 2>&1; then
+  echo "Docker is not running, please start the Docker daemon and try again! 💪"
+  exit 1
+fi
+
 check_and_set_next_port
 
 export NEXT_PUBLIC_PORT=$NEXTJS_PORT

--- a/gitpod-scripts/startCloudDevStrapi.sh
+++ b/gitpod-scripts/startCloudDevStrapi.sh
@@ -20,6 +20,11 @@ check_and_set_strapi_port() {
     fi
 }
 
+if ! docker info > /dev/null 2>&1; then
+  echo "Docker is not running, please start the Docker daemon and try again! 💪"
+  exit 1
+fi
+
 check_and_set_strapi_port
 
 printf '\nNEXT_PUBLIC_STRAPI_API_URL'="http://127.0.0.1:$STRAPI_PORT" >> app/.env

--- a/startdevenv.sh
+++ b/startdevenv.sh
@@ -37,6 +37,11 @@ check_and_set_next_port() {
     fi
 }
 
+if ! docker info > /dev/null 2>&1; then
+  echo "Docker is not running, please start the Docker daemon and try again! 💪"
+  exit 1
+fi
+
 sh startBackend.sh $1
 
 check_and_set_strapi_port


### PR DESCRIPTION
* Closes #217 

## Issue in brief
Script continues and corrupts environment when docker is not running!

## Suggested Fixes/Changes 

Added check if docker daemon is running or not before starting any of the "ENTRY" scripts for both Gitpod and Local scripts, and if it's not running then the script will terminate as shown below....

## Screenshot

<img width="744" alt="image" src="https://user-images.githubusercontent.com/73993394/211821349-70453227-bbb7-4a64-802e-1e1bb1763564.png">
