### PR TITLE
Add Contributor Metrics Widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 ![build and grow massive online communities with rocket.chat](./assets/readme-hero.png)
 
+<div align='center'>
+<a href="https://github.com/monoclehq">
+<img src="https://open-source-assets.middlewarehq.com/svgs/RocketChat-RC4Community-contributor-metrics-dark-widget.svg" ></img>
+</a>
+</div>
+
 ---
 
 <h2 align='center'>🚀 Features 🚀</h2>


### PR DESCRIPTION
# Why Do why need this ?

- Contributor recognition can help develop an active opensource community around projects.
-  A widget showcasing recent contributions can be motivating for new contributors. 
- As a mentor while going through proposal I saw that some of the contributors had mentioned their ranking on this widget for the GitHub App and EmbeddedChat projects. 
- This widget was initially rendered for [GitHub RocketChat App](https://github.com/RocketChat/Apps.Github22) but it was suggested by @Sing-Li  that it can help benefit other community projects. 

# Proposed Changes 

- Add a contributor widget hosted by [Middleware](https://www.middlewarehq.com/) that updates the contributor statistics regularly and renders updated widget.
- The Widget is served via a CDN and is updated regularly based on contributor statistics over the last 3 months.
![image](https://user-images.githubusercontent.com/70485812/235688596-8a3260cc-0d47-4ee5-b01c-43fd91e34cb0.png)